### PR TITLE
Simple treatment component

### DIFF
--- a/src/SimpleTreatment.tsx
+++ b/src/SimpleTreatment.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import SplitTreatments from './SplitTreatments';
+import { ON } from './constants';
+import { ISimpleTreatmentProps } from './types';
+
+const SimpleTreatment = ({
+  names = [],
+  attributes = {},
+  children,
+}: ISimpleTreatmentProps) => {
+  return (
+    <SplitTreatments names={names} attributes={attributes}>
+      {({ treatments, isReady }) => {
+        // https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#multiple-evaluations-at-once
+        const nameLookup = names.reduce((lookup: object, next: string) => {
+          (lookup as any)[next] = true;
+          return lookup;
+        }, {});
+
+        const allRequestedFlags = Object.keys(treatments).filter((key) => {
+          return (nameLookup as any)[key];
+        });
+
+        const allProvidedFlagsEnabled = allRequestedFlags.reduce(
+          (final, next) => {
+            if (!final) {
+              return final;
+            }
+
+            return treatments[next]?.treatment === ON;
+          },
+          true,
+        );
+
+        if (!names || !names.length) {
+          return null;
+        }
+        if (isReady && allProvidedFlagsEnabled) {
+          return children;
+        }
+
+        return null;
+      }}
+    </SplitTreatments>
+  );
+};
+
+export default SimpleTreatment;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,6 @@ export { default as useManager } from './useManager';
 
 // SplitContext
 export { default as SplitContext } from './SplitContext';
+
+// Other useful components
+export { default as SimpleTreatment } from './SimpleTreatment';

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,3 +189,21 @@ export interface ISplitTreatmentsProps {
    */
   children: ((props: ISplitTreatmentsChildProps) => JSX.Element | null);
 }
+
+export interface ISimpleTreatmentProps {
+
+  /**
+   * list of Split names
+   */
+  names: string[];
+
+  /**
+   * An object of type Attributes used to evaluate the splits.
+   */
+  attributes?: SplitIO.Attributes;
+
+  /**
+   * Children of the SplitTreatments component. It must be a functional component (child as a function) you want to show.
+   */
+  children: JSX.Element | null;
+}


### PR DESCRIPTION
# React SDK

## What did you accomplish?

**I realize this is a little more opinionated than some of the rest of the SDK - so would like your feedback before I finish adding tests + documentation.** 

My team(s), and I would guess many others, have many simple use cases which go basically like this: 

> Show the child element when the flag(s) is "on" and don't show it when it is anything else ("control", "off", etc.)


I think this component benefits developers by making it extremely simple to get started with the feature flagging for simple use cases. It is essentially just a wrapper for `SplitTreatments` that injects a bit of opinion in order to make using feature flags even easier for easy use cases. 

```javascript
// far away in some parent component
<SplitFactory>

// your first feature flag in an actual component
    <SimpleTreatment names={["my_flag", "my_other_flag"]} attributes={{ some_attribute: 1234}}>
        <ComponentToUseFeatureFlag />
    </SimpleTreatment>


</SplitFactory
```


## How do we test the changes introduced in this PR?

Will continue with unit tests once I have confirmation that the team would be interested in adding this to the SDK.



## Extra Notes